### PR TITLE
Adds a render callback which is called when the element is shown. 

### DIFF
--- a/jquery.miniTip.js
+++ b/jquery.miniTip.js
@@ -132,6 +132,9 @@
 						tt_t.html(o.title).show();
 					else
 						tt_t.hide();
+						
+					// call the render callback function
+					if (o.render) o.render(tt_w);
 					
 					// reset arrow position
 					tt_a.removeAttr('class');


### PR DESCRIPTION
When the tip is shown there is already a callback for it, but at this point the tip does neither contain content nor title. The new render callback is a function called with the finished element. This enables the caller to hook up the childelements of the tip with custom events. (Like adding a click handler to a link)

It could be done by moving and modifying the show event handler, but the new callback has the advantage of not breaking any existing code.
