### PR TITLE
Improvement for miniTip click handling when using multiple miniTip link targets.

### DIFF
--- a/jquery.miniTip.js
+++ b/jquery.miniTip.js
@@ -108,8 +108,16 @@
 						// make sure we know this was activated by click
 						tt_w.attr('click', 't');
 						
-						// show the tooltip, unless it is already showing, then close it
-						if (tt_w.css('display') == 'none') show(); else hide();
+			                        if (tt_w.data('last_target') !== el) {
+			                            // rerender the tooltip if the target changed
+			                            show();
+			                        } else {
+			                            // show the tooltip, unless it is already showing, then close it
+			                            if (tt_w.css('display') == 'none') show(); else hide();    
+			                        }
+			
+			                        tt_w.data('last_target', el);
+
 						return false;
 					});
 					


### PR DESCRIPTION
The current miniTip version will always hide the tip on every second click, independent of the target. 

This patch ensures that the tip is only hidden if the target is the same. If the target is different the tip is rerendered.

See the following examples for clarification:

How it works currently:
http://jsfiddle.net/href/HTLMn/2/

How it works after applying this patch:
http://jsfiddle.net/href/QHTQ2/8/
