### PR TITLE
Allow show() callback to access options and element context for dynamically overriding content

### DIFF
--- a/jquery.miniTip.js
+++ b/jquery.miniTip.js
@@ -79,7 +79,7 @@
 							
 							// show the tooltip
 							aHov = true;
-							show();
+							show.call(this);
 						},
 						function(){
 							aHov = false;
@@ -110,10 +110,10 @@
 						
 						if (tt_w.data('last_target') !== el) {
 							// rerender the tooltip if the target changed
-							show();
+							show.call(this);
 						} else {
 							// show the tooltip, unless it is already showing, then close it
-							if (tt_w.css('display') == 'none') show(); else hide();    
+							if (tt_w.css('display') == 'none') show.call(this); else hide();
 						}
 
 						tt_w.data('last_target', el);
@@ -130,8 +130,13 @@
 				// show the tooltip
 				var show = function() {
 					// call the show callback function
-					if (o.show) o.show.call(this);
-					
+					if (o.show) o.show.call(this, o);
+
+                    // use content set by callback, if any
+                    if (o.content && o.content != '') {
+                        cont = o.content
+                    }
+
 					// add in the content
 					tt_c.html(cont);
 					


### PR DESCRIPTION
In our app, we couldn't statically fix the content for the miniTip, instead we had a bunch of hidden div's with different contents and needed to select which div's html to use dynamically based on where the miniTip was invoked from.

To this end, I made sure that the show() callback has the "this" object context from jQuery's event handler, and I passed in the "o" objects (containing the setup options), so that the callback could modify them.

This now works for us beautifully.

-Wolf
