### PR TITLE
fix for stemOff not centered on element.

### DIFF
--- a/jquery.miniTip.js
+++ b/jquery.miniTip.js
@@ -249,7 +249,7 @@
 					// if it is going to go off on the sides, use corner
 					if (o.anchor == 'n' || o.anchor == 's') {
 						if ((tipW / 2) > left) {
-							mLeft = mLeft < 0 ? aLeft + mLeft : aLeft;
+							mLeft = mLeft < 0 ? aLeft + mLeft - o.stemOff/2 : aLeft;
 							aLeft = 0;
 						} else if ((left + tipW / 2) > parseInt($(window).width(), 10)) {
 							mLeft -= aLeft;


### PR DESCRIPTION
See fiddle in this issue: https://github.com/goldfire/miniTip/issues/16

stemOff offsets the tooltip's mleft by stemOff/2. This patch just subtracts stemOff/2 from mleft in the calculation.
